### PR TITLE
Removed namespace tags which will help spawn multiple rbcar(s) 

### DIFF
--- a/rbcar_description/robots/rbcar.urdf
+++ b/rbcar_description/robots/rbcar.urdf
@@ -126,7 +126,7 @@
   <!-- Gazebo ros control pluggins -->
   <gazebo>
     <plugin filename="libgazebo_ros_control.so" name="ros_control">
-      <robotNamespace>/rbcar</robotNamespace>
+      <!-- <robotNamespace>/rbcar</robotNamespace> -->
       <robotParam>robot_description</robotParam>
       <!-- controlPeriod>0.003</controlPeriod -->
       <controlPeriod>0.001</controlPeriod>

--- a/rbcar_description/urdf/bases/rbcar_base.gazebo.xacro
+++ b/rbcar_description/urdf/bases/rbcar_base.gazebo.xacro
@@ -6,7 +6,7 @@
   <xacro:macro name="ros_control">
     <gazebo>
       <plugin name="ros_control" filename="libgazebo_ros_control.so">
-        <robotNamespace>/rbcar</robotNamespace>
+        <!-- <robotNamespace>/rbcar</robotNamespace> -->
         <robotParam>robot_description</robotParam>
         <!-- controlPeriod>0.003</controlPeriod -->
         <controlPeriod>0.001</controlPeriod>


### PR DESCRIPTION
Removing these tags will help take on new namespaces which is used while initializing multiple rbcar(s). 
Related to [PR #11](https://github.com/RobotnikAutomation/rbcar_sim/pull/11) in rbcar_sim